### PR TITLE
#8 Allow null value to enable detach

### DIFF
--- a/src/NestedValidator.php
+++ b/src/NestedValidator.php
@@ -208,7 +208,7 @@ class NestedValidator extends AbstractNestedParser implements NestedValidatorInt
 
             // add rule if we know that the primary key should be an integer
             if ($info->model()->getIncrementing()) {
-                $rules[ $this->getNestedKeyPrefix() . $dotKey ] = 'integer';
+                $rules[ $this->getNestedKeyPrefix() . $dotKey ] = 'nullable|integer';
             }
 
             return $rules;


### PR DESCRIPTION
Fix for #8 

As the doc states:
```
        // if the data is scalar, it is treated as the primary key in a link-only operation, which should be allowed
        // if the relation is allowed in nesting at all -- if the data is null, it should be considered a detach
        // operation, which is allowed aswell.
```
`if the data is null, it should be considered a detach`
Validation rule should allow `null` value