### PR TITLE
Prevent overwriting required validation

### DIFF
--- a/src/NestedValidator.php
+++ b/src/NestedValidator.php
@@ -208,7 +208,22 @@ class NestedValidator extends AbstractNestedParser implements NestedValidatorInt
 
             // add rule if we know that the primary key should be an integer
             if ($info->model()->getIncrementing()) {
-                $rules[ $this->getNestedKeyPrefix() . $dotKey ] = 'nullable|integer';
+                $isRequired = false;
+                $key = $this->getNestedKeyPrefix() . $dotKey;
+                $validationRules = $this->getDirectModelValidationRules();
+
+                // check if the field is required in model validation
+                if (array_key_exists($key, $validationRules)) {
+                    $validationRule = $validationRules[$key];
+
+                    if (is_string($validationRule) && preg_match('/\brequired\b/', $validationRule) !== false ||
+                        in_array('required', $validationRule)
+                    ) {
+                        $isRequired = true;
+                    }
+                }
+
+                $rules[$key] = ($isRequired ? 'required' : 'nullable') . '|integer';
             }
 
             return $rules;


### PR DESCRIPTION
Related to #8
When model validation sets a nested entity to required it should not overwrite validation with `nullable`.